### PR TITLE
Add OSMC on Raspberry Pi 4 to tested kernels 

### DIFF
--- a/OSMC-RPi4-GUIDE.md
+++ b/OSMC-RPi4-GUIDE.md
@@ -1,0 +1,222 @@
+# Fenvi FU-AX1800 (MT7921au) on OSMC — Setup Guide
+
+## Environment
+
+- **Device**: Raspberry Pi 4 running OSMC
+- **Kernel**: 5.15.92-1-osmc (aarch64 kernel, armhf userland)
+- **USB Adapter**: Fenvi FU-AX1800 (MediaTek MT7921au, USB ID `0e8d:7961`)
+- **Problem**: The `mt7921u` driver was added in kernel 5.18, so it must be compiled as an out-of-tree module for kernel 5.15.
+
+---
+
+## Step 1: Install build dependencies
+
+```bash
+sudo apt update
+sudo apt install -y build-essential git libssl-dev bc file
+```
+
+If `libssl-dev` fails with a 404, download manually:
+
+```bash
+wget http://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl1.1_1.1.1w-0+deb11u4_armhf.deb -O /tmp/libssl1.1.deb
+wget http://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl-dev_1.1.1w-0+deb11u4_armhf.deb -O /tmp/libssl-dev.deb
+sudo dpkg -i /tmp/libssl1.1.deb /tmp/libssl-dev.deb
+```
+
+## Step 2: Install kernel headers and source
+
+```bash
+sudo apt install -y rbp464-headers-sanitised-5.15.92-1-osmc rbp464-source-5.15.92-1-osmc
+```
+
+> **Note**: Use `apt-cache search rbp464` if the exact version has changed.
+
+## Step 3: Create the kernel build symlink
+
+```bash
+sudo ln -sf /usr/src/rbp464-source-5.15.92-1-osmc /lib/modules/5.15.92-1-osmc/build
+```
+
+## Step 4: Install the cross-compiler
+
+The kernel is arm64 but userland is armhf, so a cross-compiler is needed:
+
+```bash
+sudo apt install -y aarch64-toolchain-osmc
+```
+
+This installs a chroot-based toolchain at `/opt/osmc-tc/aarch64-toolchain-osmc/`.
+
+## Step 5: Set up cross-compiler wrapper scripts
+
+The toolchain binaries are aarch64 ELF executables inside a chroot. They can run on the aarch64 kernel but need the correct dynamic linker and library paths. Create wrapper scripts for every tool:
+
+```bash
+# Create the dynamic linker symlink
+sudo ln -sf /opt/osmc-tc/aarch64-toolchain-osmc/lib/ld-linux-aarch64.so.1 /lib/ld-linux-aarch64.so.1
+
+# Create wrapper scripts
+sudo mkdir -p /usr/local/aarch64-cross
+for tool in $(ls /opt/osmc-tc/aarch64-toolchain-osmc/usr/bin/aarch64-linux-gnu-* | xargs -n1 basename); do
+  sudo tee /usr/local/aarch64-cross/$tool > /dev/null <<SCRIPT
+#!/bin/sh
+export LD_LIBRARY_PATH=/opt/osmc-tc/aarch64-toolchain-osmc/lib/aarch64-linux-gnu:/opt/osmc-tc/aarch64-toolchain-osmc/usr/lib/aarch64-linux-gnu
+export PATH=/usr/local/aarch64-cross:\$PATH
+exec /opt/osmc-tc/aarch64-toolchain-osmc/usr/bin/$tool "\$@"
+SCRIPT
+  sudo chmod +x /usr/local/aarch64-cross/$tool
+done
+```
+
+## Step 6: Create assembler symlinks for GCC
+
+GCC looks for `as`, `ld`, etc. (without the `aarch64-linux-gnu-` prefix) in a specific directory relative to itself. That directory doesn't exist by default:
+
+```bash
+sudo mkdir -p /opt/osmc-tc/aarch64-toolchain-osmc/usr/aarch64-linux-gnu/bin
+for tool in as ar ld ld.bfd ld.gold nm objcopy objdump ranlib readelf strip; do
+  sudo ln -sf /opt/osmc-tc/aarch64-toolchain-osmc/usr/bin/aarch64-linux-gnu-$tool \
+    /opt/osmc-tc/aarch64-toolchain-osmc/usr/aarch64-linux-gnu/bin/$tool
+done
+```
+
+## Step 7: Copy kernel config and prepare for module building
+
+```bash
+sudo cp /boot/config-5.15.92-1-osmc /usr/src/rbp464-source-5.15.92-1-osmc/.config
+
+export LD_LIBRARY_PATH=/opt/osmc-tc/aarch64-toolchain-osmc/lib/aarch64-linux-gnu:/opt/osmc-tc/aarch64-toolchain-osmc/usr/lib/aarch64-linux-gnu
+
+sudo -E make -C /usr/src/rbp464-source-5.15.92-1-osmc \
+  ARCH=arm64 \
+  CROSS_COMPILE=/usr/local/aarch64-cross/aarch64-linux-gnu- \
+  modules_prepare
+```
+
+> **Note**: Ignore the `libarmmem.so` preload warnings — they are harmless (32-bit library being skipped by 64-bit processes).
+
+## Step 8: Install firmware files
+
+```bash
+sudo mkdir -p /lib/firmware/mediatek
+
+sudo wget -O /lib/firmware/mediatek/WIFI_MT7961_patch_mcu_1_2_hdr.bin \
+  https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/plain/mediatek/WIFI_MT7961_patch_mcu_1_2_hdr.bin
+
+sudo wget -O /lib/firmware/mediatek/WIFI_RAM_CODE_MT7961_1.bin \
+  https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/plain/mediatek/WIFI_RAM_CODE_MT7961_1.bin
+```
+
+## Step 9: Clone and build the mt7921 driver
+
+```bash
+cd ~
+git clone https://github.com/tomhudak/mt7921.git
+cd mt7921
+
+export LD_LIBRARY_PATH=/opt/osmc-tc/aarch64-toolchain-osmc/lib/aarch64-linux-gnu:/opt/osmc-tc/aarch64-toolchain-osmc/usr/lib/aarch64-linux-gnu
+
+make ARCH=arm64 \
+  CROSS_COMPILE=/usr/local/aarch64-cross/aarch64-linux-gnu- \
+  CONFIG_MT76_CONNAC_LIB=m \
+  CONFIG_MT7921_COMMON=m \
+  CONFIG_MT7921U=m
+```
+
+> **Critical**: You must pass `CONFIG_MT76_CONNAC_LIB=m` on the make command line. The kernel .config doesn't include this option, and without it the `mt76-connac-lib.ko` module won't be built, causing "Unknown symbol" errors when loading.
+
+## Step 10: Install the modules
+
+```bash
+sudo -E make ARCH=arm64 \
+  CROSS_COMPILE=/usr/local/aarch64-cross/aarch64-linux-gnu- \
+  CONFIG_MT76_CONNAC_LIB=m \
+  CONFIG_MT7921_COMMON=m \
+  CONFIG_MT7921U=m \
+  modules_install
+```
+
+> The `cp: -r not specified` errors at the end are harmless (firmware directory copy issue in the install script). The `.ko` modules are installed correctly.
+
+Run depmod manually (it gets skipped due to missing `System.map`):
+
+```bash
+sudo /sbin/depmod -a
+```
+
+## Step 11: Load the driver
+
+```bash
+sudo /sbin/modprobe mt7921u
+```
+
+Verify the adapter appears:
+
+```bash
+ip link show
+# You should see wlan1 (or similar)
+
+dmesg | grep mt7921
+# Should show: "mt7921u 1-1.3:1.0: HW/SW Version: ..."
+# And: "WM Firmware Version: ..."
+```
+
+## Step 12: Configure autoload on boot
+
+```bash
+echo 'mt7921u' | sudo tee /etc/modules-load.d/mt7921u.conf
+```
+
+## Step 13: Connect to WiFi
+
+Create a connman provisioning file:
+
+```bash
+sudo tee /var/lib/connman/your-wifi.config > /dev/null <<'EOF'
+[service_your_wifi]
+Type=wifi
+Name=YOUR_SSID
+Security=psk
+Passphrase=YOUR_PASSWORD
+AutoConnect=true
+IPv4=dhcp
+EOF
+```
+
+Then restart connman and connect:
+
+```bash
+sudo systemctl restart connman
+connmanctl scan wifi
+connmanctl services
+# Find your network's service ID for wlan1 (identified by the MAC address)
+connmanctl connect wifi_XXXX_YYYY_managed_psk
+```
+
+---
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| `/lib/modules/.../build` not found | Redo step 3 (symlink) |
+| `unknown assembler invoked` during modules_prepare | Redo step 6 (assembler symlinks for GCC) |
+| `__uint128_t` error | Make sure you're using `ARCH=arm64` with the aarch64 cross-compiler |
+| `bc: not found` during modules_prepare | `sudo apt install bc` |
+| `Unknown symbol mt76_connac_*` when loading | Rebuild with `CONFIG_MT76_CONNAC_LIB=m` (step 9) |
+| `Not registered` when connecting via connmanctl | Create a provisioning file (step 13) or restart connman |
+| `libarmmem.so` preload warnings | Harmless — 32-bit library being skipped by 64-bit processes |
+| Module doesn't load after reboot | Check `/etc/modules-load.d/mt7921u.conf` exists (step 12) |
+
+## Built modules reference
+
+The following kernel modules are installed in `/lib/modules/5.15.92-1-osmc/updates/`:
+
+| Module | Purpose |
+|--------|---------|
+| `mt76/mt76.ko` | Core mt76 driver |
+| `mt76/mt76-usb.ko` | mt76 USB transport |
+| `mt76/mt76-connac-lib.ko` | mt76 connectivity library (MCU/MAC) |
+| `mt76/mt7921/mt7921-common.ko` | MT7921 common driver |
+| `mt76/mt7921/mt7921u.ko` | MT7921 USB driver (loads all deps) |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ $ sudo make install
 ```
 $ sudo make uninstall
 ```
-Note: Firmware for MT7621 will not be uninstalled.
+Note: Firmware for MT7921 will not be uninstalled.
 # Tested kernels
 1. Kernel 5.15.0-56-generic (Linux Mint 20.3 Una)
 2. Kernel 5.16.17-sun50iw6 (Orange Pi 3.0.8 Orangepi3-lts Ubuntu 22.04)
+3. Kernel 5.15.92-1-osmc (OSMC on Raspberry Pi 4, aarch64 kernel / armhf userland)

--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ Note: Firmware for MT7921 will not be uninstalled.
 # Tested kernels
 1. Kernel 5.15.0-56-generic (Linux Mint 20.3 Una)
 2. Kernel 5.16.17-sun50iw6 (Orange Pi 3.0.8 Orangepi3-lts Ubuntu 22.04)
-3. Kernel 5.15.92-1-osmc (OSMC on Raspberry Pi 4, aarch64 kernel / armhf userland)
+3. Kernel 5.15.92-1-osmc (OSMC on Raspberry Pi 4, aarch64 kernel / armhf userland) — [setup guide](OSMC-RPi4-GUIDE.md)


### PR DESCRIPTION
## Summary
- Add kernel 5.15.92-1-osmc (OSMC on Raspberry Pi 4) to the tested kernels list
- Fix typo in uninstall note: MT7621 → MT7921

## Cross-compilation notes for OSMC

OSMC on Raspberry Pi 4 runs an aarch64 kernel with armhf userland, so an aarch64 cross-compiler is required. The build also needs explicit config flags on the make command line:

```
make ARCH=arm64 \
    CROSS_COMPILE=aarch64-linux-gnu- \
    CONFIG_MT76_CONNAC_LIB=m \
    CONFIG_MT7921_COMMON=m \
    CONFIG_MT7921U=m
sudo make ARCH=arm64 \
    CROSS_COMPILE=aarch64-linux-gnu- \
    CONFIG_MT76_CONNAC_LIB=m \
    CONFIG_MT7921_COMMON=m \
    CONFIG_MT7921U=m \
    modules_install
sudo /sbin/depmod -a
```

`CONFIG_MT76_CONNAC_LIB=m` is critical — without it `mt76-connac-lib.ko` won't be built and loading the driver fails with "Unknown symbol" errors.

On OSMC, the cross-compiler is provided by the `aarch64-toolchain-osmc` package. Wrapper scripts are needed since the toolchain binaries live inside a chroot. Kernel headers/source (`rbp464-headers-sanitised-*` / `rbp464-source-*`) must also be installed and linked to `/lib/modules/<version>/build`.

## Test
- [x] Built and loaded mt7921u on OSMC with kernel 5.15.92-1-osmc on Raspberry Pi 4
- [x] Device Fenvi FU-AX1800 (MT7921au, USB ID `0e8d:7961`) detected and connected to WiFi successfully
